### PR TITLE
added audit creation optional flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,12 @@ Make sure you provide `getCurrentUser` and `getAuditLogRepository` Getter functi
 
 This will create all insert, update, delete audits for this model.
 
+- Option to disable audit logging on specific functions by just passing `noAudit:true` flag with options
+
+```ts
+create(data, {noAudit: true});
+```
+
 ## Feedback
 
 If you've noticed a bug or have a question or have a feature request, [search the issue tracker](https://github.com/sourcefuse/loopback4-audit-log/issues) to see if someone else in the community has already created a ticket.

--- a/src/mixins/audit.mixin.ts
+++ b/src/mixins/audit.mixin.ts
@@ -4,14 +4,13 @@ import {
   DataObject,
   Entity,
   EntityCrudRepository,
-  Options,
   Where,
 } from '@loopback/repository';
 import {keyBy} from 'lodash';
 
 import {Action, AuditLog} from '../models';
 import {AuditLogRepository} from '../repositories';
-import {IAuditMixin, IAuditMixinOptions} from '../types';
+import {AuditOptions, IAuditMixin, IAuditMixinOptions} from '../types';
 
 export function AuditRepositoryMixin<
   M extends Entity,
@@ -26,9 +25,12 @@ export function AuditRepositoryMixin<
 
     /* eslint-disable-next-line @typescript-eslint/ban-ts-comment */
     // @ts-ignore
-    async create(dataObject: DataObject<M>, options?: Options): Promise<M> {
+    async create(
+      dataObject: DataObject<M>,
+      options?: AuditOptions,
+    ): Promise<M> {
       const created = await super.create(dataObject, options);
-      if (this.getCurrentUser) {
+      if (this.getCurrentUser && !options.noAuditCreation) {
         const user = await this.getCurrentUser();
         const auditRepo = await this.getAuditLogRepository();
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -58,10 +60,10 @@ export function AuditRepositoryMixin<
     // @ts-ignore
     async createAll(
       dataObjects: DataObject<M>[],
-      options?: Options,
+      options?: AuditOptions,
     ): Promise<M[]> {
       const created = await super.createAll(dataObjects, options);
-      if (this.getCurrentUser) {
+      if (this.getCurrentUser && !options.noAuditCreation) {
         const user = await this.getCurrentUser();
         const auditRepo = await this.getAuditLogRepository();
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -96,8 +98,11 @@ export function AuditRepositoryMixin<
     async updateAll(
       dataObject: DataObject<M>,
       where?: Where<M>,
-      options?: Options,
+      options?: AuditOptions,
     ): Promise<Count> {
+      if (options.noAuditCreation) {
+        return super.updateAll(dataObject, where, options);
+      }
       const toUpdate = await this.find({where});
       const beforeMap = keyBy(toUpdate, d => d.getId());
       const updatedCount = await super.updateAll(dataObject, where, options);
@@ -137,7 +142,10 @@ export function AuditRepositoryMixin<
 
     /* eslint-disable-next-line @typescript-eslint/ban-ts-comment */
     // @ts-ignore
-    async deleteAll(where?: Where<M>, options?: Options): Promise<Count> {
+    async deleteAll(where?: Where<M>, options?: AuditOptions): Promise<Count> {
+      if (options.noAuditCreation) {
+        return super.deleteAll(where, options);
+      }
       const toDelete = await this.find({where});
       const beforeMap = keyBy(toDelete, d => d.getId());
       const deletedCount = await super.deleteAll(where, options);
@@ -178,9 +186,14 @@ export function AuditRepositoryMixin<
     async updateById(
       id: ID,
       data: DataObject<M>,
-      options?: Options,
+      options?: AuditOptions,
     ): Promise<void> {
+      if (options.noAuditCreation) {
+        return super.updateById(id, data, options);
+      }
       const before = await this.findById(id);
+      // loopback repository internally calls updateAll so we don't want to create another log
+      options.noAuditCreation = true;
       await super.updateById(id, data, options);
       const after = await this.findById(id);
 
@@ -216,8 +229,11 @@ export function AuditRepositoryMixin<
     async replaceById(
       id: ID,
       data: DataObject<M>,
-      options?: Options,
+      options?: AuditOptions,
     ): Promise<void> {
+      if (options.noAuditCreation) {
+        return super.replaceById(id, data, options);
+      }
       const before = await this.findById(id);
       await super.replaceById(id, data, options);
       const after = await this.findById(id);
@@ -251,7 +267,10 @@ export function AuditRepositoryMixin<
 
     /* eslint-disable-next-line @typescript-eslint/ban-ts-comment */
     // @ts-ignore
-    async deleteById(id: ID, options?: Options): Promise<void> {
+    async deleteById(id: ID, options?: AuditOptions): Promise<void> {
+      if (options.noAuditCreation) {
+        return super.deleteById(id, options);
+      }
       const before = await this.findById(id);
       await super.deleteById(id, options);
 

--- a/src/mixins/audit.mixin.ts
+++ b/src/mixins/audit.mixin.ts
@@ -30,7 +30,7 @@ export function AuditRepositoryMixin<
       options?: AuditOptions,
     ): Promise<M> {
       const created = await super.create(dataObject, options);
-      if (this.getCurrentUser && !options.noAuditCreation) {
+      if (this.getCurrentUser && !options?.noAudit) {
         const user = await this.getCurrentUser();
         const auditRepo = await this.getAuditLogRepository();
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -63,7 +63,7 @@ export function AuditRepositoryMixin<
       options?: AuditOptions,
     ): Promise<M[]> {
       const created = await super.createAll(dataObjects, options);
-      if (this.getCurrentUser && !options.noAuditCreation) {
+      if (this.getCurrentUser && !options?.noAudit) {
         const user = await this.getCurrentUser();
         const auditRepo = await this.getAuditLogRepository();
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -100,7 +100,7 @@ export function AuditRepositoryMixin<
       where?: Where<M>,
       options?: AuditOptions,
     ): Promise<Count> {
-      if (options.noAuditCreation) {
+      if (options?.noAudit) {
         return super.updateAll(dataObject, where, options);
       }
       const toUpdate = await this.find({where});
@@ -143,7 +143,7 @@ export function AuditRepositoryMixin<
     /* eslint-disable-next-line @typescript-eslint/ban-ts-comment */
     // @ts-ignore
     async deleteAll(where?: Where<M>, options?: AuditOptions): Promise<Count> {
-      if (options.noAuditCreation) {
+      if (options?.noAudit) {
         return super.deleteAll(where, options);
       }
       const toDelete = await this.find({where});
@@ -188,12 +188,16 @@ export function AuditRepositoryMixin<
       data: DataObject<M>,
       options?: AuditOptions,
     ): Promise<void> {
-      if (options.noAuditCreation) {
+      if (options?.noAudit) {
         return super.updateById(id, data, options);
       }
       const before = await this.findById(id);
       // loopback repository internally calls updateAll so we don't want to create another log
-      options.noAuditCreation = true;
+      if (options) {
+        options.noAudit = true;
+      } else {
+        options = {noAudit: true};
+      }
       await super.updateById(id, data, options);
       const after = await this.findById(id);
 
@@ -231,7 +235,7 @@ export function AuditRepositoryMixin<
       data: DataObject<M>,
       options?: AuditOptions,
     ): Promise<void> {
-      if (options.noAuditCreation) {
+      if (options?.noAudit) {
         return super.replaceById(id, data, options);
       }
       const before = await this.findById(id);
@@ -268,7 +272,7 @@ export function AuditRepositoryMixin<
     /* eslint-disable-next-line @typescript-eslint/ban-ts-comment */
     // @ts-ignore
     async deleteById(id: ID, options?: AuditOptions): Promise<void> {
-      if (options.noAuditCreation) {
+      if (options?.noAudit) {
         return super.deleteById(id, options);
       }
       const before = await this.findById(id);

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,7 @@
 import {AuditLogRepository} from './repositories';
+import {Options} from '@loopback/repository';
 
 export const AuditDbSourceName = 'AuditDB';
-import {Options} from '@loopback/repository';
 export interface IAuditMixin<UserID> {
   getAuditLogRepository: () => Promise<AuditLogRepository>;
   getCurrentUser?: () => Promise<{id?: UserID}>;
@@ -13,6 +13,6 @@ export interface IAuditMixinOptions {
   [key: string]: any;
 }
 interface AuditLogOption {
-  noAuditCreation: boolean;
+  noAudit: boolean;
 }
 export declare type AuditOptions = Options & AuditLogOption;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,7 @@
 import {AuditLogRepository} from './repositories';
 
 export const AuditDbSourceName = 'AuditDB';
-
+import {Options} from '@loopback/repository';
 export interface IAuditMixin<UserID> {
   getAuditLogRepository: () => Promise<AuditLogRepository>;
   getCurrentUser?: () => Promise<{id?: UserID}>;
@@ -12,3 +12,7 @@ export interface IAuditMixinOptions {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   [key: string]: any;
 }
+interface AuditLogOption {
+  noAuditCreation: boolean;
+}
+export declare type AuditOptions = Options & AuditLogOption;

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,7 +12,7 @@ export interface IAuditMixinOptions {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   [key: string]: any;
 }
-interface AuditLogOption {
+export interface AuditLogOption {
   noAudit: boolean;
 }
 export declare type AuditOptions = Options & AuditLogOption;


### PR DESCRIPTION
RPMS-4260
fixes multiple audit logging when updating by Id  as loopback repository internally calls updateAll so we don't want to create another log