### PR TITLE
fix (audit): fix issue if audit mixin is invoked when currentUser doesn't exist

### DIFF
--- a/src/mixins/audit.mixin.ts
+++ b/src/mixins/audit.mixin.ts
@@ -39,7 +39,7 @@ export function AuditRepositoryMixin<
         const audit = new AuditLog({
           actedAt: new Date(),
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          actor: (user?.id as any).toString() ?? '0',
+          actor: (user?.id as any)?.toString() ?? '0',
           action: Action.INSERT_ONE,
           after: created.toJSON(),
           entityId: created.getId(),


### PR DESCRIPTION
## Description

- [x] fix the issue if audit mixin is invoked when currentUser doesn't exist, error related to `toString` method not exist on undefined

Fixes # Cannot read property`toString` of `undefined`

## Type of change

- [x] Bug fix 

## Checklist:

- [x] Performed a self-review of my own code
- [x] Code conforms with the style guide