### PR TITLE
fix(mixin): forward `options` param to `find` and `findById` calls

### DIFF
--- a/.cz-config.js
+++ b/.cz-config.js
@@ -32,6 +32,7 @@ module.exports = {
     {name: 'provider'},
     {name: 'core'},
     {name: 'maintenance'},
+    {name: 'mixin'},
   ],
 
   appendBranchNameToCommitMessage: true,

--- a/src/__tests__/unit/audit.mixin.unit.ts
+++ b/src/__tests__/unit/audit.mixin.unit.ts
@@ -11,6 +11,7 @@ import {consoleMessage} from '../acceptance/audit.mixin.acceptance';
 import {
   MockClass,
   mockClassMethodCall,
+  optionsReceivedByParentRepository,
   resetMethodCalls,
 } from './fixtures/mockClass';
 import {mockData, mockDataArray, resetMockData} from './fixtures/mockData';
@@ -249,6 +250,21 @@ describe('Audit Mixin', () => {
     //check if super class method called
     expect(mockClassMethodCall.updateById).to.be.true();
   });
+
+  it("should forward the options param to base repository's findById method", async () => {
+    const options = {someTestKey: 'someTestValue'};
+    await returnedMixedClassInstance.updateById(
+      mockData.id,
+      {
+        itemName: 'replacedTestItemName',
+        description: 'replacedTestItemDescription',
+      },
+      options,
+    );
+
+    // check if findById received the options originally passed to mixined class
+    expect(optionsReceivedByParentRepository.findById).to.be.eql(options);
+  });
   it('should update record and create appropriate Audit Log on calling updateById method', async () => {
     const beforeMockData = Object.assign({}, mockData);
 
@@ -337,6 +353,21 @@ describe('Audit Mixin', () => {
 
     //check if super class method called
     expect(mockClassMethodCall.updateAll).to.be.true();
+  });
+
+  it("should forward the options param to base repository's find method", async () => {
+    const options = {someKey: 'someValue'};
+    await returnedMixedClassInstance.updateAll(
+      {
+        itemName: 'replacedTestItemName',
+        description: 'replacedTestItemDescription',
+      },
+      undefined,
+      options,
+    );
+
+    // check if find method received the options originally passed to mixined class
+    expect(optionsReceivedByParentRepository.find).to.be.eql(options);
   });
 
   it('should update records and create appropriate Audit Logs on calling updateAll method', async () => {

--- a/src/__tests__/unit/fixtures/mockClass.ts
+++ b/src/__tests__/unit/fixtures/mockClass.ts
@@ -34,6 +34,7 @@ export class MockClass extends DefaultCrudRepository<
     filter?: FilterExcludingWhere<MockModel>,
     options?: AnyObject,
   ): Promise<MockModel> {
+    optionsReceivedByParentRepository.findById = options;
     return new Promise(resolve => {
       const mockDataToReturn = Object.assign({}, mockData);
       resolve(mockDataToReturn);
@@ -109,6 +110,7 @@ export class MockClass extends DefaultCrudRepository<
     });
   }
   find(filter?: Filter<MockModel>, options?: AnyObject): Promise<MockModel[]> {
+    optionsReceivedByParentRepository.find = options;
     return new Promise(resolve => {
       const mockDataArrayToReturn: MockModel[] = [];
       mockDataArray.forEach(data => {
@@ -158,6 +160,10 @@ export const mockClassMethodCall = {
   replaceById: false,
   updateAll: false,
 };
+export const optionsReceivedByParentRepository: {
+  findById?: AnyObject;
+  find?: AnyObject;
+} = {};
 export function resetMethodCalls() {
   mockClassMethodCall.create = false;
   mockClassMethodCall.createAll = false;

--- a/src/mixins/audit.mixin.ts
+++ b/src/mixins/audit.mixin.ts
@@ -114,10 +114,10 @@ export function AuditRepositoryMixin<
       if (options?.noAudit) {
         return super.updateAll(dataObject, where, options);
       }
-      const toUpdate = await this.find({where});
+      const toUpdate = await this.find({where}, options);
       const beforeMap = keyBy(toUpdate, d => d.getId());
       const updatedCount = await super.updateAll(dataObject, where, options);
-      const updated = await this.find({where});
+      const updated = await this.find({where}, options);
 
       if (this.getCurrentUser) {
         const user = await this.getCurrentUser();
@@ -157,7 +157,7 @@ export function AuditRepositoryMixin<
       if (options?.noAudit) {
         return super.deleteAll(where, options);
       }
-      const toDelete = await this.find({where});
+      const toDelete = await this.find({where}, options);
       const beforeMap = keyBy(toDelete, d => d.getId());
       const deletedCount = await super.deleteAll(where, options);
 
@@ -202,7 +202,7 @@ export function AuditRepositoryMixin<
       if (options?.noAudit) {
         return super.updateById(id, data, options);
       }
-      const before = await this.findById(id);
+      const before = await this.findById(id, undefined, options);
       // loopback repository internally calls updateAll so we don't want to create another log
       if (options) {
         options.noAudit = true;
@@ -250,9 +250,9 @@ export function AuditRepositoryMixin<
       if (options?.noAudit) {
         return super.replaceById(id, data, options);
       }
-      const before = await this.findById(id);
+      const before = await this.findById(id, undefined, options);
       await super.replaceById(id, data, options);
-      const after = await this.findById(id);
+      const after = await this.findById(id, undefined, options);
 
       if (this.getCurrentUser) {
         const user = await this.getCurrentUser();
@@ -287,7 +287,7 @@ export function AuditRepositoryMixin<
       if (options?.noAudit) {
         return super.deleteById(id, options);
       }
-      const before = await this.findById(id);
+      const before = await this.findById(id, undefined, options);
       await super.deleteById(id, options);
 
       if (this.getCurrentUser) {


### PR DESCRIPTION
## Description

Fixes the implementation of updateAll, deleteAll, updateById and replaceById to forward the options params.

GH-64
Fixes #64

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Intermediate change (work in progress)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

## Checklist:

- [x] Performed a self-review of my own code
- [x] npm test passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the style guide
- [ ] API Documentation in code was updated
- [ ] Any dependent changes have been merged and published in downstream modules
