### PR TITLE
feat(sequelize): add sequelize support

### DIFF
--- a/.cz-config.js
+++ b/.cz-config.js
@@ -33,6 +33,7 @@ module.exports = {
     {name: 'core'},
     {name: 'maintenance'},
     {name: 'mixin'},
+    {name: 'sequelize'},
   ],
 
   appendBranchNameToCommitMessage: true,

--- a/README.md
+++ b/README.md
@@ -238,6 +238,42 @@ export class GroupRepository extends ConditionalAuditRepositoryMixin(
 }
 ```
 
+## Using with Sequelize ORM
+
+This extension provides support to both juggler (the default loopback ORM) and sequelize.
+
+If your loopback project is already using `SequelizeCrudRepository` from [@loopback/sequelize](https://www.npmjs.com/package/@loopback/sequelize) or equivalent add on repositories from sourceloop packages like [`SequelizeUserModifyCrudRepository`](https://sourcefuse.github.io/arc-docs/arc-api-docs/packages/core/#sequelizeusermodifycrudrepository). You'll need to make just two changes:
+
+1. The import statements should have the suffix `/sequelize`, like below:
+
+```ts
+import {
+  AuditRepositoryMixin,
+  AuditLogRepository,
+} from '@sourceloop/audit-log/sequelize';
+```
+
+2. The Audit datasource's parent class should be `SequelizeDataSource`.
+
+```ts
+import {SequelizeDataSource} from '@loopback/sequelize';
+
+export class AuditDataSource
+  extends SequelizeDataSource
+  implements LifeCycleObserver
+{
+  static dataSourceName = AuditDbSourceName;
+  static readonly defaultConfig = config;
+
+  constructor(
+    @inject('datasources.config.audit', {optional: true})
+    dsConfig: object = config,
+  ) {
+    super(dsConfig);
+  }
+}
+```
+
 ## Feedback
 
 If you've noticed a bug or have a question or have a feature request, [search the issue tracker](https://github.com/sourcefuse/loopback4-audit-log/issues) to see if someone else in the community has already created a ticket.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,17 @@
 {
   "name": "@sourceloop/audit-log",
-  "version": "4.0.0",
+  "version": "5.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sourceloop/audit-log",
-      "version": "4.0.0",
+      "version": "5.0.0",
       "dependencies": {
         "@loopback/boot": "^5.0.9",
         "@loopback/core": "^4.0.9",
         "@loopback/repository": "^5.1.5",
+        "@loopback/sequelize": "^0.2.0",
         "jsdom": "^20.0.3",
         "lodash": "^4.17.21",
         "tslib": "^2.4.1"
@@ -1230,6 +1231,23 @@
         "@loopback/core": "^4.0.10"
       }
     },
+    "node_modules/@loopback/sequelize": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@loopback/sequelize/-/sequelize-0.2.0.tgz",
+      "integrity": "sha512-7Gg2PA1l1j1istoMig7Z0e0QJE+SxeM5TKvlXiskHdvZvZYdOcjohQwxVY3fPQC0QCJ+sdfmibX8mXj9bOu3wQ==",
+      "dependencies": {
+        "debug": "^4.3.4",
+        "sequelize": "^6.31.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": "14 || 16 || 17 || 18"
+      },
+      "peerDependencies": {
+        "@loopback/core": "^4.0.10",
+        "@loopback/repository": "^5.1.5"
+      }
+    },
     "node_modules/@loopback/service-proxy": {
       "version": "5.0.9",
       "license": "MIT",
@@ -1934,6 +1952,11 @@
       "version": "8.3.4",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/validator": {
+      "version": "13.7.17",
+      "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.7.17.tgz",
+      "integrity": "sha512-aqayTNmeWrZcvnG2MG9eGYI6b7S5fl+yKgPs6bAjOTwPS316R5SxBGKvtSExfyoJU7pIeHJfsHI0Ji41RVMkvQ=="
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "5.59.1",
@@ -3819,6 +3842,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/dottie": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dottie/-/dottie-2.0.3.tgz",
+      "integrity": "sha512-4liA0PuRkZWQFQjwBypdxPfZaRWiv5tkhMXY2hzsa2pNf5s7U3m9cwUchfNKe8wZQxdGPQQzO6Rm2uGe0rvohQ=="
     },
     "node_modules/duplexer2": {
       "version": "0.1.4",
@@ -6129,7 +6157,6 @@
     },
     "node_modules/lru-cache": {
       "version": "6.0.0",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "yallist": "^4.0.0"
@@ -6617,6 +6644,25 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/moment": {
+      "version": "2.29.4",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
+      "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/moment-timezone": {
+      "version": "0.5.43",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.43.tgz",
+      "integrity": "sha512-72j3aNyuIsDxdF1i7CEgV2FfxM1r6aaqJyLB2vwb33mXYyoyLly+F1zbWqhA3/bVIoJ4szlUoMbUnVdid32NUQ==",
+      "dependencies": {
+        "moment": "^2.29.4"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/ms": {
@@ -10516,6 +10562,11 @@
         "node": ">=8"
       }
     },
+    "node_modules/pg-connection-string": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.6.0.tgz",
+      "integrity": "sha512-x14ibktcwlHKoHxx9X3uTVW9zIGR41ZB6QNhHb21OPNdCCO3NaRnpJuwKIQSR4u+Yqjx4HCvy7Hh7VSy1U4dGg=="
+    },
     "node_modules/picocolors": {
       "version": "1.0.0",
       "dev": true,
@@ -11143,6 +11194,11 @@
         "node": ">= 4"
       }
     },
+    "node_modules/retry-as-promised": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/retry-as-promised/-/retry-as-promised-7.0.4.tgz",
+      "integrity": "sha512-XgmCoxKWkDofwH8WddD0w85ZfqYz+ZHlr5yo+3YUCfycWawU56T5ckWXsScsj5B8tqUcIG67DxXByo3VUgiAdA=="
+    },
     "node_modules/reusify": {
       "version": "1.0.4",
       "dev": true,
@@ -11325,7 +11381,6 @@
     },
     "node_modules/semver": {
       "version": "7.3.7",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -11426,6 +11481,83 @@
         "no-case": "^3.0.4",
         "tslib": "^2.0.3",
         "upper-case-first": "^2.0.2"
+      }
+    },
+    "node_modules/sequelize": {
+      "version": "6.31.1",
+      "resolved": "https://registry.npmjs.org/sequelize/-/sequelize-6.31.1.tgz",
+      "integrity": "sha512-cahWtRrYLjqoZP/aurGBoaxn29qQCF4bxkAUPEQ/ozjJjt6mtL4Q113S3N39mQRmX5fgxRbli+bzZARP/N51eg==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/sequelize"
+        }
+      ],
+      "dependencies": {
+        "@types/debug": "^4.1.7",
+        "@types/validator": "^13.7.1",
+        "debug": "^4.3.3",
+        "dottie": "^2.0.2",
+        "inflection": "^1.13.2",
+        "lodash": "^4.17.21",
+        "moment": "^2.29.1",
+        "moment-timezone": "^0.5.35",
+        "pg-connection-string": "^2.5.0",
+        "retry-as-promised": "^7.0.3",
+        "semver": "^7.3.5",
+        "sequelize-pool": "^7.1.0",
+        "toposort-class": "^1.0.1",
+        "uuid": "^8.3.2",
+        "validator": "^13.7.0",
+        "wkx": "^0.5.0"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ibm_db": {
+          "optional": true
+        },
+        "mariadb": {
+          "optional": true
+        },
+        "mysql2": {
+          "optional": true
+        },
+        "oracledb": {
+          "optional": true
+        },
+        "pg": {
+          "optional": true
+        },
+        "pg-hstore": {
+          "optional": true
+        },
+        "snowflake-sdk": {
+          "optional": true
+        },
+        "sqlite3": {
+          "optional": true
+        },
+        "tedious": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/sequelize-pool": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/sequelize-pool/-/sequelize-pool-7.1.0.tgz",
+      "integrity": "sha512-G9c0qlIWQSK29pR/5U2JF5dDQeqqHRragoyahj/Nx4KOOQ3CPPfzxnfqFPCSB7x5UgjOgnZ61nSxz+fjDpRlJg==",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/sequelize/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/serialize-javascript": {
@@ -12193,6 +12325,11 @@
         "node": ">=0.6"
       }
     },
+    "node_modules/toposort-class": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toposort-class/-/toposort-class-1.0.1.tgz",
+      "integrity": "sha512-OsLcGGbYF3rMjPUf8oKktyvCiUxSbqMMS39m33MAjLTC1DVIH6x3WSt63/M77ihI09+Sdfk1AXvfhCEeUmC7mg=="
+    },
     "node_modules/tough-cookie": {
       "version": "4.1.2",
       "license": "BSD-3-Clause",
@@ -12531,6 +12668,14 @@
         "spdx-expression-parse": "^3.0.0"
       }
     },
+    "node_modules/validator": {
+      "version": "13.9.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.9.0.tgz",
+      "integrity": "sha512-B+dGG8U3fdtM0/aNK4/X8CXq/EcxU2WPrPEkJGslb47qyHsxmbggTWK0yEA4qnYVNF+nxNlN88o14hIcPmSIEA==",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/vary": {
       "version": "1.1.2",
       "dev": true,
@@ -12619,6 +12764,14 @@
       "version": "2.0.0",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/wkx": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/wkx/-/wkx-0.5.0.tgz",
+      "integrity": "sha512-Xng/d4Ichh8uN4l0FToV/258EjMGU9MGcA0HV2d9B/ZpZB3lqQm7nkOdZdm5GhKtLLhAE7PiVQwN4eN+2YJJUg==",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/word-wrap": {
       "version": "1.2.3",
@@ -12716,7 +12869,6 @@
     },
     "node_modules/yallist": {
       "version": "4.0.0",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/yaml": {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,20 @@
   ],
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "exports": {
+    ".": "./dist/index.js",
+    "./sequelize": {
+      "types": "./dist/index.sequelize.d.ts",
+      "default": "./dist/index.sequelize.js"
+    }
+  },
+  "typesVersions": {
+    "*": {
+      "sequelize": [
+        "./dist/index.sequelize.d.ts"
+      ]
+    }
+  },
   "engines": {
     "node": ">=16"
   },
@@ -46,6 +60,7 @@
     "@loopback/boot": "^5.0.9",
     "@loopback/core": "^4.0.9",
     "@loopback/repository": "^5.1.5",
+    "@loopback/sequelize": "^0.2.0",
     "jsdom": "^20.0.3",
     "lodash": "^4.17.21",
     "tslib": "^2.4.1"

--- a/src/index.sequelize.ts
+++ b/src/index.sequelize.ts
@@ -1,0 +1,5 @@
+export * from './component';
+export * from './mixins';
+export * from './types';
+export * from './models';
+export * from './repositories/sequelize';

--- a/src/mixins/audit.mixin.ts
+++ b/src/mixins/audit.mixin.ts
@@ -1,16 +1,12 @@
-import {
-  Count,
-  DataObject,
-  DefaultCrudRepository,
-  Entity,
-  Where,
-} from '@loopback/repository';
+import {Count, DataObject, Entity, Where} from '@loopback/repository';
 import {keyBy, cloneDeep} from 'lodash';
 
 import {Action, AuditLog} from '../models';
 import {AuditLogRepository} from '../repositories';
+import {AuditLogRepository as SequelizeAuditLogRepository} from '../repositories/sequelize';
 import {
   AbstractConstructor,
+  AuditMixinBase,
   AuditOptions,
   IAuditMixin,
   IAuditMixinOptions,
@@ -23,7 +19,7 @@ export function AuditRepositoryMixin<
   Relations extends object,
   UserID,
   //sonarignore:end
-  R extends AbstractConstructor<DefaultCrudRepository<M, ID, Relations>>,
+  R extends AuditMixinBase<M, ID, Relations>,
 >(
   superClass: R,
   opts: IAuditMixinOptions,
@@ -32,7 +28,9 @@ export function AuditRepositoryMixin<
     extends superClass
     implements IAuditMixin<UserID>
   {
-    getAuditLogRepository: () => Promise<AuditLogRepository>;
+    getAuditLogRepository: () => Promise<
+      AuditLogRepository | SequelizeAuditLogRepository
+    >;
     getCurrentUser?: () => Promise<{id?: UserID}>;
 
     async create(

--- a/src/repositories/sequelize/audit.repository.ts
+++ b/src/repositories/sequelize/audit.repository.ts
@@ -1,0 +1,18 @@
+import {inject} from '@loopback/core';
+import {AuditLog} from '../../models';
+import {AuditDbSourceName} from '../../types';
+import {
+  SequelizeCrudRepository,
+  SequelizeDataSource,
+} from '@loopback/sequelize';
+
+export class AuditLogRepository extends SequelizeCrudRepository<
+  AuditLog,
+  typeof AuditLog.prototype.id
+> {
+  constructor(
+    @inject(`datasources.${AuditDbSourceName}`) dataSource: SequelizeDataSource,
+  ) {
+    super(AuditLog, dataSource);
+  }
+}

--- a/src/repositories/sequelize/index.ts
+++ b/src/repositories/sequelize/index.ts
@@ -1,0 +1,1 @@
+export * from './audit.repository';

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,9 +1,20 @@
 import {AuditLogRepository} from './repositories';
-import {Options} from '@loopback/repository';
+import {AuditLogRepository as SequelizeAuditLogRepository} from './repositories/sequelize';
+import {
+  Count,
+  DataObject,
+  Entity,
+  Filter,
+  FilterExcludingWhere,
+  Options,
+  Where,
+} from '@loopback/repository';
 
 export const AuditDbSourceName = 'AuditDB';
 export interface IAuditMixin<UserID> {
-  getAuditLogRepository: () => Promise<AuditLogRepository>;
+  getAuditLogRepository: () => Promise<
+    AuditLogRepository | SequelizeAuditLogRepository
+  >;
   getCurrentUser?: () => Promise<{id?: UserID}>;
 }
 
@@ -21,3 +32,30 @@ export type AbstractConstructor<T> = abstract new (
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   ...args: any[]
 ) => T;
+
+export type MixinBaseClass<T> = AbstractConstructor<T>;
+
+export type AuditMixinBase<T extends Entity, ID, Relations> = MixinBaseClass<{
+  entityClass: typeof Entity & {
+    prototype: T;
+  };
+  find(filter?: Filter<T>, options?: Options): Promise<(T & Relations)[]>;
+  findById(
+    id: ID,
+    filter?: FilterExcludingWhere<T>,
+    options?: Options,
+  ): Promise<T & Relations>;
+  create(entity: DataObject<T>, options?: Options): Promise<T>;
+  createAll(entities: DataObject<T>[], options?: Options): Promise<T[]>;
+  update(entity: T, options?: Options): Promise<void>;
+  delete(entity: T, options?: Options): Promise<void>;
+  updateAll(
+    data: DataObject<T>,
+    where?: Where<T>,
+    options?: Options,
+  ): Promise<Count>;
+  updateById(id: ID, data: DataObject<T>, options?: Options): Promise<void>;
+  replaceById(id: ID, data: DataObject<T>, options?: Options): Promise<void>;
+  deleteAll(where?: Where<T>, options?: Options): Promise<Count>;
+  deleteById(id: ID, options?: Options): Promise<void>;
+}>;


### PR DESCRIPTION
## Description

- Modified mixin argument type to accept non default crud repositories as well. (needed in order to enable usage of Sequelize Repository as the argument of mixin).
- Added directory import syntax to provide sequelize specific artifacts (currently just the repository).

GH-69

Fixes #69

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Intermediate change (work in progress)

## How Has This Been Tested?

- [x] Tested in loopback app: https://github.com/shubhamp-sf/audit-service-example/releases/tag/v1-unpublished

## Checklist:

- [x] Performed a self-review of my own code
- [x] npm test passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the style guide
- [ ] API Documentation in code was updated
- [ ] Any dependent changes have been merged and published in downstream modules
