### PR TITLE
feat(mixin): making the actor field configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,44 @@ This will create all insert, update, delete audits for this model.
 create(data, {noAudit: true});
 ```
 
+- The Actor field is now configurable and can save any string type value in the field.
+  Though the default value will be userId a developer can save any string field from the current User that is being passed.
+
+```ts
+export interface User<ID = string, TID = string, UTID = string> {
+  id?: string;
+  username: string;
+  password?: string;
+  identifier?: ID;
+  permissions: string[];
+  authClientId: number;
+  email?: string;
+  role: string;
+  firstName: string;
+  lastName: string;
+  middleName?: string;
+  tenantId?: TID;
+  userTenantId?: UTID;
+  passwordExpiryTime?: Date;
+  allowedResources?: string[];
+}
+```
+
+### Steps
+
+1. All you need to do is bind a User key to the ActorIdKey in application.ts
+
+```ts
+this.bind(AuthServiceBindings.ActorIdKey).to('username');
+```
+
+2. Pass the actorIdKey argument in the constructor
+
+```ts
+@inject(AuditBindings.ActorIdKey, {optional: true})
+public actorIdKey?: ActorId,
+```
+
 - The package exposes a conditional mixin for your repository classes. Just extend your repository class with `ConditionalAuditRepositoryMixin`, for all those repositories where you need audit data based on condition whether `ADD_AUDIT_LOG_MIXIN` is set true. See an example below. For a model `Group`, here we are extending the `GroupRepository` with `AuditRepositoryMixin`.
 
 ```ts

--- a/README.md
+++ b/README.md
@@ -276,6 +276,15 @@ export class GroupRepository extends ConditionalAuditRepositoryMixin(
 }
 ```
 
+### Making current user not mandatory
+
+Incase you dont have current user binded in your application context and wish to log the activities within your application then in that case you can pass the actor id along with the
+options just like
+
+```ts
+await productRepo.create(product, {noAudit: false, actorId: 'userId'});
+```
+
 ## Using with Sequelize ORM
 
 This extension provides support to both juggler (the default loopback ORM) and sequelize.

--- a/src/__tests__/acceptance/audit.mixin.acceptance.ts
+++ b/src/__tests__/acceptance/audit.mixin.acceptance.ts
@@ -1,6 +1,6 @@
 import {expect, sinon} from '@loopback/testlab';
 import {v4 as uuidv4} from 'uuid';
-import {Action} from '../..';
+import {Action, User} from '../..';
 import {TestAuditDataSource} from './fixtures/datasources/audit.datasource';
 import {TestDataSource} from './fixtures/datasources/test.datasource';
 import {TestModel} from './fixtures/models/test.model';
@@ -16,9 +16,16 @@ console.error = (message: string) => {
   consoleMessage = message;
 };
 
-const mockUser = {
-  id: 'testId',
-  name: 'testName',
+const mockUser: User = {
+  id: 'testCurrentUserId',
+  username: 'testCurrentUserName',
+  authClientId: 123,
+  permissions: ['1', '2', '3'],
+  role: 'admin',
+  firstName: 'test',
+  lastName: 'lastname',
+  tenantId: 'tenantId',
+  userTenantId: 'userTenantId',
 };
 
 describe('Audit Mixin', () => {
@@ -27,6 +34,7 @@ describe('Audit Mixin', () => {
   const auditLogRepositoryInstance = new TestAuditLogRepository(
     new TestAuditDataSource(),
   );
+  const actorIdKey = 'id';
   const getAuditLogRepository = sinon
     .stub()
     .resolves(auditLogRepositoryInstance);
@@ -34,6 +42,7 @@ describe('Audit Mixin', () => {
     testDataSourceInstance,
     getCurrentUser,
     getAuditLogRepository,
+    actorIdKey,
   );
 
   beforeEach(async () => {

--- a/src/__tests__/acceptance/fixtures/repositories/test.repository.ts
+++ b/src/__tests__/acceptance/fixtures/repositories/test.repository.ts
@@ -1,7 +1,12 @@
 import {Constructor, Getter} from '@loopback/core';
 import {DefaultCrudRepository} from '@loopback/repository';
 
-import {AuditRepositoryMixin, IAuditMixinOptions} from '../../../..';
+import {
+  ActorId,
+  AuditRepositoryMixin,
+  IAuditMixinOptions,
+  User,
+} from '../../../..';
 import {TestDataSource} from '../datasources/test.datasource';
 import {TestModel, TestModelRelations} from '../models/test.model';
 import {TestAuditLogRepository} from './audit.repository';
@@ -25,8 +30,9 @@ export class TestRepository extends AuditRepositoryMixin<
 >(DefaultCrudRepository, testAuditOpts) {
   constructor(
     dataSource: TestDataSource,
-    public getCurrentUser: Getter<{name: string; id: string}>,
+    public getCurrentUser: Getter<User>,
     public getAuditLogRepository: Getter<TestAuditLogRepository>,
+    public actorIdKey?: ActorId,
   ) {
     super(TestModel, dataSource);
   }

--- a/src/__tests__/unit/audit.mixin.unit.ts
+++ b/src/__tests__/unit/audit.mixin.unit.ts
@@ -6,6 +6,7 @@ import {
   AuditLog,
   AuditRepositoryMixin,
   IAuditMixinOptions,
+  User,
 } from '../..';
 import {consoleMessage} from '../acceptance/audit.mixin.acceptance';
 import {
@@ -49,9 +50,16 @@ class MockAuditRepoError {
 const mockOpts: IAuditMixinOptions = {
   actionKey: 'Test_Logs',
 };
-const mockUser = {
+const mockUser: User = {
   id: 'testCurrentUserId',
-  name: 'testCurrentUserName',
+  username: 'testCurrentUserName',
+  authClientId: 123,
+  permissions: ['1', '2', '3'],
+  role: 'admin',
+  firstName: 'test',
+  lastName: 'lastname',
+  tenantId: 'tenantId',
+  userTenantId: 'userTenantId',
 };
 
 describe('Audit Mixin', () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,3 +3,4 @@ export * from './mixins';
 export * from './types';
 export * from './models';
 export * from './repositories';
+export * from './keys';

--- a/src/keys.ts
+++ b/src/keys.ts
@@ -1,0 +1,6 @@
+import {BindingKey} from '@loopback/core';
+import {ActorId} from './types';
+
+export namespace AuditBindings {
+  export const ActorIdKey = BindingKey.create<ActorId>(`sf.audit.actorid`);
+}

--- a/src/mixins/audit.mixin.ts
+++ b/src/mixins/audit.mixin.ts
@@ -6,10 +6,12 @@ import {AuditLogRepository} from '../repositories';
 import {AuditLogRepository as SequelizeAuditLogRepository} from '../repositories/sequelize';
 import {
   AbstractConstructor,
+  ActorId,
   AuditMixinBase,
   AuditOptions,
   IAuditMixin,
   IAuditMixinOptions,
+  User,
 } from '../types';
 
 //sonarignore:start
@@ -31,7 +33,8 @@ export function AuditRepositoryMixin<
     getAuditLogRepository: () => Promise<
       AuditLogRepository | SequelizeAuditLogRepository
     >;
-    getCurrentUser?: () => Promise<{id?: UserID}>;
+    getCurrentUser?: () => Promise<User>;
+    actorIdKey?: ActorId;
 
     async create(
       dataObject: DataObject<M>,
@@ -47,7 +50,7 @@ export function AuditRepositoryMixin<
         const audit = new AuditLog({
           actedAt: new Date(),
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          actor: (user?.id as any)?.toString() ?? '0', //NOSONAR
+          actor: (user[this.actorIdKey ?? 'id'] as any)?.toString() ?? '0', //NOSONAR
           action: Action.INSERT_ONE,
           after: created.toJSON(),
           entityId: created.getId(),
@@ -83,7 +86,7 @@ export function AuditRepositoryMixin<
             new AuditLog({
               actedAt: new Date(),
               // eslint-disable-next-line @typescript-eslint/no-explicit-any
-              actor: (user?.id as any).toString() ?? '0', //NOSONAR
+              actor: (user[this.actorIdKey ?? 'id'] as any)?.toString() ?? '0', //NOSONAR
               action: Action.INSERT_MANY,
               after: data.toJSON(),
               entityId: data.getId(),
@@ -128,7 +131,7 @@ export function AuditRepositoryMixin<
             new AuditLog({
               actedAt: new Date(),
               // eslint-disable-next-line @typescript-eslint/no-explicit-any
-              actor: (user?.id as any).toString() ?? '0', //NOSONAR
+              actor: (user[this.actorIdKey ?? 'id'] as any)?.toString() ?? '0', //NOSONAR
               action: Action.UPDATE_MANY,
               before: (beforeMap[data.getId()] as Entity).toJSON(),
               after: data.toJSON(),
@@ -170,7 +173,7 @@ export function AuditRepositoryMixin<
             new AuditLog({
               actedAt: new Date(),
               // eslint-disable-next-line @typescript-eslint/no-explicit-any
-              actor: (user?.id as any).toString() ?? '0', //NOSONAR
+              actor: (user[this.actorIdKey ?? 'id'] as any)?.toString() ?? '0', //NOSONAR
               action: Action.DELETE_MANY,
               before: (beforeMap[data.getId()] as Entity).toJSON(),
               entityId: data.getId(),
@@ -220,7 +223,7 @@ export function AuditRepositoryMixin<
         const auditLog = new AuditLog({
           actedAt: new Date(),
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          actor: (user?.id as any).toString() ?? '0', //NOSONAR
+          actor: (user[this.actorIdKey ?? 'id'] as any)?.toString() ?? '0', //NOSONAR
           action: Action.UPDATE_ONE,
           before: before.toJSON(),
           after: after.toJSON(),
@@ -261,7 +264,7 @@ export function AuditRepositoryMixin<
         const auditLog = new AuditLog({
           actedAt: new Date(),
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          actor: (user?.id as any).toString() ?? '0', //NOSONAR
+          actor: (user[this.actorIdKey ?? 'id'] as any)?.toString() ?? '0', //NOSONAR
           action: Action.UPDATE_ONE,
           before: before.toJSON(),
           after: after.toJSON(),
@@ -297,7 +300,7 @@ export function AuditRepositoryMixin<
         const auditLog = new AuditLog({
           actedAt: new Date(),
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          actor: (user?.id as any).toString() ?? '0', //NOSONAR
+          actor: (user[this.actorIdKey ?? 'id'] as any)?.toString() ?? '0', //NOSONAR
           action: Action.DELETE_ONE,
           before: before.toJSON(),
           entityId: before.getId(),

--- a/src/mixins/audit.mixin.ts
+++ b/src/mixins/audit.mixin.ts
@@ -49,7 +49,7 @@ export function AuditRepositoryMixin<
         delete extras.actionKey;
         const audit = new AuditLog({
           actedAt: new Date(),
-          actor: this.getActor(user, this.actorIdKey, options?.actorId),
+          actor: this.getActor(user, options?.actorId),
           action: Action.INSERT_ONE,
           after: created.toJSON(),
           entityId: created.getId(),
@@ -84,7 +84,7 @@ export function AuditRepositoryMixin<
           data =>
             new AuditLog({
               actedAt: new Date(),
-              actor: this.getActor(user, this.actorIdKey, options?.actorId),
+              actor: this.getActor(user, options?.actorId),
               action: Action.INSERT_MANY,
               after: data.toJSON(),
               entityId: data.getId(),
@@ -128,7 +128,7 @@ export function AuditRepositoryMixin<
           data =>
             new AuditLog({
               actedAt: new Date(),
-              actor: this.getActor(user, this.actorIdKey, options?.actorId),
+              actor: this.getActor(user, options?.actorId),
               action: Action.UPDATE_MANY,
               before: (beforeMap[data.getId()] as Entity).toJSON(),
               after: data.toJSON(),
@@ -169,7 +169,7 @@ export function AuditRepositoryMixin<
           data =>
             new AuditLog({
               actedAt: new Date(),
-              actor: this.getActor(user, this.actorIdKey, options?.actorId),
+              actor: this.getActor(user, options?.actorId),
               action: Action.DELETE_MANY,
               before: (beforeMap[data.getId()] as Entity).toJSON(),
               entityId: data.getId(),
@@ -218,7 +218,7 @@ export function AuditRepositoryMixin<
         delete extras.actionKey;
         const auditLog = new AuditLog({
           actedAt: new Date(),
-          actor: this.getActor(user, this.actorIdKey, options?.actorId),
+          actor: this.getActor(user, options?.actorId),
           action: Action.UPDATE_ONE,
           before: before.toJSON(),
           after: after.toJSON(),
@@ -258,7 +258,7 @@ export function AuditRepositoryMixin<
         delete extras.actionKey;
         const auditLog = new AuditLog({
           actedAt: new Date(),
-          actor: this.getActor(user, this.actorIdKey, options?.actorId),
+          actor: this.getActor(user, options?.actorId),
           action: Action.UPDATE_ONE,
           before: before.toJSON(),
           after: after.toJSON(),
@@ -293,7 +293,7 @@ export function AuditRepositoryMixin<
         delete extras.actionKey;
         const auditLog = new AuditLog({
           actedAt: new Date(),
-          actor: this.getActor(user, this.actorIdKey, options?.actorId),
+          actor: this.getActor(user, options?.actorId),
           action: Action.DELETE_ONE,
           before: before.toJSON(),
           entityId: before.getId(),
@@ -335,7 +335,7 @@ export function AuditRepositoryMixin<
           data =>
             new AuditLog({
               actedAt: new Date(),
-              actor: this.getActor(user, this.actorIdKey, options?.actorId),
+              actor: this.getActor(user, options?.actorId),
               action: Action.DELETE_MANY,
               before: (beforeMap[data.getId()] as Entity).toJSON(),
               entityId: data.getId(),
@@ -374,7 +374,7 @@ export function AuditRepositoryMixin<
         delete extras.actionKey;
         const auditLog = new AuditLog({
           actedAt: new Date(),
-          actor: this.getActor(user, this.actorIdKey, options?.actorId),
+          actor: this.getActor(user, options?.actorId),
           action: Action.DELETE_ONE,
           before: before.toJSON(),
           entityId: before.getId(),
@@ -392,15 +392,11 @@ export function AuditRepositoryMixin<
         });
       }
     }
-    getActor(
-      user: User,
-      actorIdKey?: ActorId,
-      optionsActorId?: string,
-    ): string {
+    getActor(user: User, optionsActorId?: string): string {
       return (
         optionsActorId ??
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (user[actorIdKey ?? 'id'] as any)?.toString() ?? //NOSOAR
+        (user[this.actorIdKey ?? 'id'] as any)?.toString() ?? //NOSOAR
         '0'
       );
     }

--- a/src/mixins/audit.mixin.ts
+++ b/src/mixins/audit.mixin.ts
@@ -49,11 +49,7 @@ export function AuditRepositoryMixin<
         delete extras.actionKey;
         const audit = new AuditLog({
           actedAt: new Date(),
-          actor:
-            options?.actorId ??
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            (user[this.actorIdKey ?? 'id'] as any)?.toString() ?? //NOSONAR
-            '0',
+          actor: this.getActor(user, this.actorIdKey, options?.actorId),
           action: Action.INSERT_ONE,
           after: created.toJSON(),
           entityId: created.getId(),
@@ -88,11 +84,7 @@ export function AuditRepositoryMixin<
           data =>
             new AuditLog({
               actedAt: new Date(),
-              actor:
-                options?.actorId ??
-                // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                (user[this.actorIdKey ?? 'id'] as any)?.toString() ?? //NOSONAR
-                '0',
+              actor: this.getActor(user, this.actorIdKey, options?.actorId),
               action: Action.INSERT_MANY,
               after: data.toJSON(),
               entityId: data.getId(),
@@ -136,11 +128,7 @@ export function AuditRepositoryMixin<
           data =>
             new AuditLog({
               actedAt: new Date(),
-              actor:
-                options?.actorId ??
-                // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                (user[this.actorIdKey ?? 'id'] as any)?.toString() ?? //NOSONAR
-                '0',
+              actor: this.getActor(user, this.actorIdKey, options?.actorId),
               action: Action.UPDATE_MANY,
               before: (beforeMap[data.getId()] as Entity).toJSON(),
               after: data.toJSON(),
@@ -181,11 +169,7 @@ export function AuditRepositoryMixin<
           data =>
             new AuditLog({
               actedAt: new Date(),
-              actor:
-                options?.actorId ??
-                // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                (user[this.actorIdKey ?? 'id'] as any)?.toString() ?? //NOSONAR
-                '0',
+              actor: this.getActor(user, this.actorIdKey, options?.actorId),
               action: Action.DELETE_MANY,
               before: (beforeMap[data.getId()] as Entity).toJSON(),
               entityId: data.getId(),
@@ -234,11 +218,7 @@ export function AuditRepositoryMixin<
         delete extras.actionKey;
         const auditLog = new AuditLog({
           actedAt: new Date(),
-          actor:
-            options?.actorId ??
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            (user[this.actorIdKey ?? 'id'] as any)?.toString() ?? //NOSONAR
-            '0',
+          actor: this.getActor(user, this.actorIdKey, options?.actorId),
           action: Action.UPDATE_ONE,
           before: before.toJSON(),
           after: after.toJSON(),
@@ -278,11 +258,7 @@ export function AuditRepositoryMixin<
         delete extras.actionKey;
         const auditLog = new AuditLog({
           actedAt: new Date(),
-          actor:
-            options?.actorId ??
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            (user[this.actorIdKey ?? 'id'] as any)?.toString() ?? //NOSONAR
-            '0',
+          actor: this.getActor(user, this.actorIdKey, options?.actorId),
           action: Action.UPDATE_ONE,
           before: before.toJSON(),
           after: after.toJSON(),
@@ -317,12 +293,7 @@ export function AuditRepositoryMixin<
         delete extras.actionKey;
         const auditLog = new AuditLog({
           actedAt: new Date(),
-
-          actor:
-            options?.actorId ??
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            (user[this.actorIdKey ?? 'id'] as any)?.toString() ?? //NOSONAR
-            '0',
+          actor: this.getActor(user, this.actorIdKey, options?.actorId),
           action: Action.DELETE_ONE,
           before: before.toJSON(),
           entityId: before.getId(),
@@ -345,7 +316,7 @@ export function AuditRepositoryMixin<
       options?: AuditOptions,
     ): Promise<Count> {
       if (!super.deleteAllHard) {
-        return Promise.resolve({count: 0});
+        throw new Error('Method not Found');
       }
       if (options?.noAudit) {
         return super.deleteAllHard(where, options);
@@ -364,11 +335,7 @@ export function AuditRepositoryMixin<
           data =>
             new AuditLog({
               actedAt: new Date(),
-              actor:
-                options?.actorId ??
-                // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                (user[this.actorIdKey ?? 'id'] as any)?.toString() ?? //NOSONAR
-                '0',
+              actor: this.getActor(user, this.actorIdKey, options?.actorId),
               action: Action.DELETE_MANY,
               before: (beforeMap[data.getId()] as Entity).toJSON(),
               entityId: data.getId(),
@@ -391,7 +358,7 @@ export function AuditRepositoryMixin<
 
     async deleteByIdHard(id: ID, options?: AuditOptions): Promise<void> {
       if (!super.deleteByIdHard) {
-        return;
+        throw new Error('Method not Found');
       }
       if (options?.noAudit) {
         return super.deleteByIdHard(id, options);
@@ -407,11 +374,7 @@ export function AuditRepositoryMixin<
         delete extras.actionKey;
         const auditLog = new AuditLog({
           actedAt: new Date(),
-          actor:
-            options?.actorId ??
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            (user[this.actorIdKey ?? 'id'] as any)?.toString() ?? //NOSOAR
-            '0',
+          actor: this.getActor(user, this.actorIdKey, options?.actorId),
           action: Action.DELETE_ONE,
           before: before.toJSON(),
           entityId: before.getId(),
@@ -428,6 +391,18 @@ export function AuditRepositoryMixin<
           //sonarignore:end
         });
       }
+    }
+    getActor(
+      user: User,
+      actorIdKey?: ActorId,
+      optionsActorId?: string,
+    ): string {
+      return (
+        optionsActorId ??
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (user[actorIdKey ?? 'id'] as any)?.toString() ?? //NOSOAR
+        '0'
+      );
     }
   }
   return MixedRepository;

--- a/src/mixins/conditional-audit.mixin.ts
+++ b/src/mixins/conditional-audit.mixin.ts
@@ -1,5 +1,5 @@
-import {DefaultCrudRepository, Entity} from '@loopback/repository';
-import {AbstractConstructor, IAuditMixinOptions} from '../types';
+import {Entity} from '@loopback/repository';
+import {AuditMixinBase, IAuditMixinOptions} from '../types';
 import {AuditRepositoryMixin} from './audit.mixin';
 
 /**
@@ -10,11 +10,11 @@ export function ConditionalAuditRepositoryMixin<
   T extends Entity,
   ID,
   Relations extends object,
-  S extends AbstractConstructor<DefaultCrudRepository<T, ID, Relations>>,
+  S extends AuditMixinBase<T, ID, Relations>,
 >(
-  constructor: S & AbstractConstructor<DefaultCrudRepository<T, ID, Relations>>,
+  constructor: S & AuditMixinBase<T, ID, Relations>,
   opt: IAuditMixinOptions,
-): S & AbstractConstructor<DefaultCrudRepository<T, ID, Relations>> {
+): S & AuditMixinBase<T, ID, Relations> {
   const ConditionalRepo =
     process.env.ADD_AUDIT_LOG_MIXIN === 'true'
       ? AuditRepositoryMixin<T, ID, Relations, string, S>(constructor, opt)

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,11 +11,13 @@ import {
 } from '@loopback/repository';
 
 export const AuditDbSourceName = 'AuditDB';
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 export interface IAuditMixin<UserID> {
   getAuditLogRepository: () => Promise<
     AuditLogRepository | SequelizeAuditLogRepository
   >;
-  getCurrentUser?: () => Promise<{id?: UserID}>;
+  getCurrentUser?: () => Promise<User>;
+  actorIdKey?: ActorId;
 }
 
 export interface IAuditMixinOptions {
@@ -59,3 +61,23 @@ export type AuditMixinBase<T extends Entity, ID, Relations> = MixinBaseClass<{
   deleteAll(where?: Where<T>, options?: Options): Promise<Count>;
   deleteById(id: ID, options?: Options): Promise<void>;
 }>;
+
+export interface User<ID = string, TID = string, UTID = string> {
+  id?: string;
+  username: string;
+  password?: string;
+  identifier?: ID;
+  permissions: string[];
+  authClientId: number;
+  email?: string;
+  role: string;
+  firstName: string;
+  lastName: string;
+  middleName?: string;
+  tenantId?: TID;
+  userTenantId?: UTID;
+  passwordExpiryTime?: Date;
+  allowedResources?: string[];
+}
+
+export type ActorId = Extract<keyof User, string>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -27,6 +27,7 @@ export interface IAuditMixinOptions {
 }
 export interface AuditLogOption {
   noAudit: boolean;
+  actorId?: string;
 }
 export declare type AuditOptions = Options & AuditLogOption;
 
@@ -60,6 +61,8 @@ export type AuditMixinBase<T extends Entity, ID, Relations> = MixinBaseClass<{
   replaceById(id: ID, data: DataObject<T>, options?: Options): Promise<void>;
   deleteAll(where?: Where<T>, options?: Options): Promise<Count>;
   deleteById(id: ID, options?: Options): Promise<void>;
+  deleteAllHard?(where?: Where<T>, options?: Options): Promise<Count>;
+  deleteByIdHard?(id: ID, options?: Options): Promise<void>;
 }>;
 
 export interface User<ID = string, TID = string, UTID = string> {


### PR DESCRIPTION
## Description

1) Added an optional constructor argument actorIdKey that can be injected via application context.
   It can accepts User key of the type string.
   the default value for the actorIdKey will be id as in it will save the userId keeping the current functionality intact.
2) Now hard delete methods are available -- deleteAllHard() and deleteByIdHard()
3) If current user is not bounded to any value in the application context then actorId field can be passed through the options.

Fixes #68

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Intermediate change (work in progress)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

## Checklist:

- [x] Performed a self-review of my own code
- [x] npm test passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the style guide
- [ ] API Documentation in code was updated
- [ ] Any dependent changes have been merged and published in downstream modules
